### PR TITLE
Add support for passing a zoom control component as prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ minScale	| number	| 'auto'	| The minimum scale to which the image can be zoomed 
 maxScale	| number	| 1			| The maximum scale to which the image can be zoomed in. 
 position    | 'center' or 'topLeft'    | 'topLeft'  | Position of the image relative to the container. Applies when the scaled image is smaller than the container.
 zoomButtons	| bool		| true		| Render plus (+) and minus (-) buttons on top of the image as another way to access the zoom feature.
+customZoomButtons	| component	| null		| Pass your own zoom buttons component. Will receive the following props: `scale`, `minScale`, `maxScale`, `onZoomInClick`, `onZoomOutClick`.
 doubleTapBehavior	| 'reset' or 'zoom' | 'reset'		| Whether to zoom in or reset to initial scale on double-click / double-tap.
 
 ## Development

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -55,6 +55,56 @@ const FlexContainerView = ({menu}) => (
     </div>
 )
 
+const CustomZoomButtons = ({ scale, minScale, maxScale, onZoomInClick, onZoomOutClick }) => {
+    const buttonStyles = {
+        width: "50px",
+        height: "50px",
+        borderRadius: "50%",
+        backgroundColor: "white",
+        border: "1px solid #ccc",
+        display: "flex",
+        flexFlow: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        cursor: "pointer",
+        marginTop: "20px"
+    };
+    return (
+        <div style={{ position: "absolute", bottom: "20px", right: "20px", zIndex: 1 }}>
+            <button type="button" style={buttonStyles} onClick={onZoomOutClick} disabled={scale <= minScale} title="Zoom Out">
+                <svg width="19" height="19" fill="none">
+                    <line x1="0" y1="9.5" x2="19" y2="9.5" stroke="#000" />
+                </svg>
+            </button>
+            <button type="button" style={buttonStyles} onClick={onZoomInClick} disabled={scale >= maxScale} title="Zoom In">
+                <svg width="19" height="19" fill="none">
+                    <line x1="0" y1="9.5" x2="19" y2="9.5" stroke="#000" />
+                    <line x1="9.5" y1="0" x2="9.5" y2="19" stroke="#000" />
+                </svg>
+            </button>
+        </div>
+
+    )
+};
+
+const CustomZoomButtonsView = ({ menu }) => {
+    const width = 300;
+    const height =  500;
+    const imageWidth = width * 2;
+    const imageHeight = height * 2;
+    return (
+        <div>
+            <nav>{menu}</nav>
+            <main style={{ width: `${width}px`, height: `${height}px`, position: "relative"}}>
+                <PinchZoomPan debug={isDevelopment()} zoomButtons={false} customZoomButtons={CustomZoomButtons}>
+                    <img alt='Demo Image' src={`http://picsum.photos/${imageWidth}/${imageHeight}?random`} />
+                </PinchZoomPan>
+            </main>
+        </div>
+    );
+}
+
+
 const Menu = ({viewId, onViewChange}) => {
     const getLinkStyle = linkViewId => {
         return {
@@ -70,6 +120,7 @@ const Menu = ({viewId, onViewChange}) => {
             <span style={{fontSize: 20, fontWeight: 'bold', padding: 10}}>Demo</span>
             <a href='#' onClick={() => onViewChange(0)} style={getLinkStyle(0)}>Small</a>
             <a href='#' onClick={() => onViewChange(1)} style={getLinkStyle(1)}>Medium</a>
+            <a href='#' onClick={() => onViewChange(4)} style={getLinkStyle(4)}>Custom zoom buttons</a>
             <a href='#' onClick={() => onViewChange(3)} style={getLinkStyle(3)}>Centered</a>
             <a href='#' onClick={() => onViewChange(2)} style={getLinkStyle(2)}>Full-screen Flex</a>
         </React.Fragment>
@@ -91,7 +142,8 @@ class App extends React.Component {
         const { viewId } = this.state;
         const menu = <Menu viewId={viewId} onViewChange={this.handleViewChange} />
         return (
-            viewId === 2 ? <FlexContainerView menu={menu} />
+            viewId === 4 ? <CustomZoomButtonsView menu={menu} />
+            : viewId === 2 ? <FlexContainerView menu={menu} />
             : viewId === 3 ? <CenteredView menu={menu} width={300} height={500} imageWidth={200} imageHeight={400} />
             : viewId === 1 ? <SizedContainerView menu={menu} width={500} height={800} />
             : <SizedContainerView menu={menu} width={300} height={500} />

--- a/src/PinchZoomPan.js
+++ b/src/PinchZoomPan.js
@@ -510,6 +510,8 @@ export default class PinchZoomPan extends React.Component {
             touchAction: touchAction,
         };
 
+        const CustomZoomButtons = this.props.customZoomButtons;
+
         return (
             <div style={containerStyle}>
                 {zoomButtons && this.isImageReady && this.isTransformInitialized && <ZoomButtons 
@@ -518,6 +520,13 @@ export default class PinchZoomPan extends React.Component {
                     maxScale={maxScale} 
                     onZoomOutClick={this.handleZoomOutClick} 
                     onZoomInClick={this.handleZoomInClick} 
+                />}
+                {CustomZoomButtons && <CustomZoomButtons 
+                    scale={scale}
+                    minScale={getMinScale(this.state, this.props)}
+                    maxScale={maxScale}
+                    onZoomOutClick={this.handleZoomOutClick}
+                    onZoomInClick={this.handleZoomInClick}
                 />}
                 {debug && <DebugView {...this.state} overflow={imageOverflow(this.state)} />}
                 {React.cloneElement(childElement, {
@@ -610,6 +619,7 @@ PinchZoomPan.defaultProps = {
     maxScale: 1,
     position: 'topLeft',
     zoomButtons: true,
+    customZoomButtons: null,
     doubleTapBehavior: 'reset'
 };
 
@@ -626,6 +636,10 @@ PinchZoomPan.propTypes = {
     maxScale: PropTypes.number,
     position: PropTypes.oneOf(['topLeft', 'center']),
     zoomButtons: PropTypes.bool,
+    customZoomButtons: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.element
+    ]),
     doubleTapBehavior: PropTypes.oneOf(['reset', 'zoom']),
     initialTop: PropTypes.number,
     initialLeft: PropTypes.number,


### PR DESCRIPTION
I added support for passing a component for the zoom buttons as a prop. My use case is that I needed to customize them (both style and behavior). The passed component can be either a class or pure function.

The README is updated with the new prop, and I've provided a working example in the demo.

Thanks !