### PR TITLE
fix CSS undefined in IE11

### DIFF
--- a/src/PinchZoomPan.js
+++ b/src/PinchZoomPan.js
@@ -577,7 +577,7 @@ export default class PinchZoomPan extends React.Component {
     }
 
     get controlOverscrollViaCss() {
-        return CSS && CSS.supports('touch-action', 'pan-up');
+        return window.CSS && window.CSS.supports('touch-action', 'pan-up');
     }
 
     calculateNegativeSpace(scale) {


### PR DESCRIPTION
Just added `window.` so IE11 won't crash and die :(

This is a MAJOR bug that crashes IE11 but the fix is a minor one, can you please merge?

![image](https://user-images.githubusercontent.com/6969966/65241010-3998dd80-daeb-11e9-82a0-9b88febfbce8.png)

![image](https://user-images.githubusercontent.com/6969966/65241280-d0fe3080-daeb-11e9-8b1a-443b54d84043.png)
