### PR TITLE
Use 2nd level imports for better tree-shaking (reduce bundle size by 200KB)

### DIFF
--- a/src/ZoomButtons.js
+++ b/src/ZoomButtons.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlus, faMinus } from '@fortawesome/free-solid-svg-icons';
+import faPlus from '@fortawesome/free-solid-svg-icons/faPlus';
+import faMinus from '@fortawesome/free-solid-svg-icons/faMinus';
 
 import './styles.css';
 


### PR DESCRIPTION
The default create-react-app webpack build doesn't properly tree-shake the fontawesome icon import, causing the entire fontawesome icon library to be added to the bundle. This caused my app's bundle size to jump over 200KB after adding this library :-). Using 2nd level imports caused only the two icons actually used to be imported, as expected. This is arguably more of an issue with create-react-app since it should properly tree-shake something like this, but it's a simple-enough change that should have a wide impact on bundle sizes. 

source-map-explorer output for a create-react-app that lists react-responsive-pinch-zoom-pan as a huge dependency (values are uncompressed, but it's still the largest dependency, accounting for 22% of my bundle size):
![Screen Shot 2020-02-05 at 9 05 36 PM](https://user-images.githubusercontent.com/371795/73907806-842db300-485c-11ea-98b4-df3275279a90.png)
