### PR TITLE
Add onChange callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ maxScale	| number	| 1			| The maximum scale to which the image can be zoomed in.
 position    | 'center' or 'topLeft'    | 'topLeft'  | Position of the image relative to the container. Applies when the scaled image is smaller than the container.
 zoomButtons	| bool		| true		| Render plus (+) and minus (-) buttons on top of the image as another way to access the zoom feature.
 doubleTapBehavior	| 'reset' or 'zoom' | 'reset'		| Whether to zoom in or reset to initial scale on double-click / double-tap.
+onChange    | function  | () => {}  | A callback function that will receive the updated `left`, `scale`, and `top` values.
 
 ## Development
 

--- a/src/PinchZoomPan.js
+++ b/src/PinchZoomPan.js
@@ -387,7 +387,10 @@ export default class PinchZoomPan extends React.Component {
 
                 //animation runs until we reach the target
                 if (!isEqualTransform(nextTransform, this.state)) {
-                    this.setState(nextTransform, () => this.animation = requestAnimationFrame(frame));
+                    this.setState(nextTransform, () => {
+                        this.animation = requestAnimationFrame(frame);
+                        this.state.onChange(nextTransform);
+                    });
                 }
             };
             this.animation = requestAnimationFrame(frame);
@@ -396,7 +399,7 @@ export default class PinchZoomPan extends React.Component {
                 top,
                 left,
                 scale,
-            });
+            }, () => this.state.onChange({ left, scale, top }));
         }
     }
 
@@ -541,12 +544,14 @@ export default class PinchZoomPan extends React.Component {
         if (nextProps.initialTop !== prevState.initialTop ||
             nextProps.initialLeft !== prevState.initialLeft ||
             nextProps.initialScale !== prevState.initialScale || 
-            nextProps.position !== prevState.position) {
+            nextProps.position !== prevState.position ||
+            nextProps.onChange !== prevState.onChange) {
             return {
                 position: nextProps.position,
                 initialScale: nextProps.initialScale,
                 initialTop: nextProps.initialTop,
                 initialLeft: nextProps.initialLeft,
+                onChange: nextProps.onChange
             };
         } else {
             return null;
@@ -610,7 +615,8 @@ PinchZoomPan.defaultProps = {
     maxScale: 1,
     position: 'topLeft',
     zoomButtons: true,
-    doubleTapBehavior: 'reset'
+    doubleTapBehavior: 'reset',
+    onChange: () => {}
 };
 
 PinchZoomPan.propTypes = {
@@ -629,4 +635,5 @@ PinchZoomPan.propTypes = {
     doubleTapBehavior: PropTypes.oneOf(['reset', 'zoom']),
     initialTop: PropTypes.number,
     initialLeft: PropTypes.number,
+    onChange: PropTypes.func,
 };


### PR DESCRIPTION
This allows a consumer to take action based on the current values, e.g. disabling a carousel's scrolling when an image is zoomed so panning & scrolling don't interfere with each other.